### PR TITLE
Fix issues with TextEntry hotkey branch

### DIFF
--- a/pyglet/gui/frame.py
+++ b/pyglet/gui/frame.py
@@ -50,16 +50,6 @@ class Frame:
             for j in range(min_vec[1], max_vec[1] + 1):
                 self._cells.get((i, j)).remove(widget)
 
-    def on_key_press(self, symbol, modifiers):
-        """Pass the event to any widgets within range of the mouse"""
-        for widget in self._cells.get(self._hash(*self._mouse_pos), set()):
-            widget.on_key_press(symbol, modifiers)
-
-    def on_key_release(self, symbol, modifiers):
-        """Pass the event to any widgets within range of the mouse"""
-        for widget in self._cells.get(self._hash(*self._mouse_pos), set()):
-            widget.on_key_release(symbol, modifiers)
-
     def on_mouse_press(self, x, y, buttons, modifiers):
         """Pass the event to any widgets within range of the mouse"""
         for widget in self._cells.get(self._hash(x, y), set()):

--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -302,14 +302,13 @@ class Slider(WidgetBase):
             `group` : `~pyglet.graphics.Group`
                 Optional parent group of the slider.
         """
-        super().__init__(x, y, base.width, max(base.height, knob.height))
+        super().__init__(x, y, base.width, knob.height)
         self._edge = edge
         self._base_img = base
         self._knob_img = knob
         self._half_knob_width = knob.width / 2
         self._half_knob_height = knob.height / 2
         self._knob_img.anchor_y = knob.height / 2
-        self._knob_to_base_height_ratio = knob.height / base.height
 
         self._min_knob_x = x + edge
         self._max_knob_x = x + base.width - knob.width - edge
@@ -324,23 +323,10 @@ class Slider(WidgetBase):
         self._in_update = False
 
     def _update_position(self):
-        self._min_knob_x = self._x + self._edge
-        self._max_knob_x = self._x + self._base_spr.width - self._knob_spr.width - self._edge
         self._base_spr.position = self._x, self._y, 0
-        self._knob_spr.position = self._x + self._edge, self._y + self._base_spr.height / 2, 0
+        self._knob_spr.position = self._x + self._edge, self._y + self._base_img.height / 2, 0
         self.value = self._value
 
-    def on_resize(self, width, height):
-        super(Slider, self).on_resize(width, height)
-        self._base_spr.width = width
-        if self._knob_to_base_height_ratio > 1:
-            self._knob_spr.height = height
-            self._base_spr.height = height / self._knob_to_base_height_ratio
-        else:
-            self._base_spr.height = height
-            self._knob_spr.height = height * self._knob_to_base_height_ratio
-        self._update_position()
-        
     @property
     def value(self):
         return self._value

--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -69,10 +69,6 @@ class WidgetBase(EventDispatcher):
         :type: int
         """
         return self._width
-    
-    @width.setter
-    def width(self, value):
-        self.on_resize(value, self._height)
 
     @property
     def height(self):
@@ -81,18 +77,6 @@ class WidgetBase(EventDispatcher):
         :type: int
         """
         return self._height
-    
-    @height.setter
-    def height(self, value):
-        self.on_resize(self._width, value)
-
-    @property
-    def size(self):
-        return (self.width, self.height)
-
-    @size.setter
-    def size(self, size_value):
-        self.on_resize(size_value[0], size_value[1])
 
     @property
     def aabb(self):
@@ -119,10 +103,6 @@ class WidgetBase(EventDispatcher):
     @value.setter
     def value(self, value):
         raise NotImplementedError("Value depends on control type!")
-    
-    def on_resize(self, width, height):
-        self._width = width
-        self._height = height
 
     def _check_hit(self, x, y):
         return self._x < x < self._x + self._width and self._y < y < self._y + self._height
@@ -152,12 +132,6 @@ class WidgetBase(EventDispatcher):
         pass
 
     def on_text_motion_select(self, motion):
-        pass
-
-    def on_key_press(self, symbol, modifiers):
-        pass
-    
-    def on_key_release(self, symbol, modifiers):
         pass
 
 

--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -509,11 +509,6 @@ class TextEntry(WidgetBase):
         else:
             self._set_focus(False)
 
-    def on_resize(self, width, height):
-        super(TextEntry, self).on_resize(width, height)
-        self._layout.width, self._layout.height = width, height
-        self._outline.width, self._outline.height = width + self._pad * 2, height + self._pad * 2
-
     def on_text(self, text):
         if not self.enabled:
             return

--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -240,10 +240,6 @@ class PushButton(WidgetBase):
             return
         self._sprite.image = self._hover_img if self._check_hit(x, y) else self._depressed_img
 
-    def on_resize(self, width, height):
-        super(PushButton, self).on_resize(width, height)
-        self._sprite.width = width
-        self._sprite.height = height
 
 PushButton.register_event_type('on_press')
 PushButton.register_event_type('on_release')

--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -517,7 +517,7 @@ class TextEntry(WidgetBase):
     def on_key_press(self, symbol, modifiers):
         if not self._focus:
             return
-        if symbol == pyglet.window.key.A and modifiers & pyglet.window.key.MOD_CTRL:
+        if symbol == pyglet.window.key.A and modifiers & pyglet.window.key.MOD_ACCEL:
             self._caret.select_all()
 
     def on_text(self, text):

--- a/pyglet/gui/widgets.py
+++ b/pyglet/gui/widgets.py
@@ -514,12 +514,6 @@ class TextEntry(WidgetBase):
         self._layout.width, self._layout.height = width, height
         self._outline.width, self._outline.height = width + self._pad * 2, height + self._pad * 2
 
-    def on_key_press(self, symbol, modifiers):
-        if not self._focus:
-            return
-        if symbol == pyglet.window.key.A and modifiers & pyglet.window.key.MOD_ACCEL:
-            self._caret.select_all()
-
     def on_text(self, text):
         if not self.enabled:
             return

--- a/pyglet/text/caret.py
+++ b/pyglet/text/caret.py
@@ -513,9 +513,14 @@ class Caret:
         GUI toolkits should filter keyboard and text events by widget focus
         before invoking this handler.
         """
-        if self.mark is None:
-            self.mark = self.position
-        self.on_text_motion(motion, True)
+        # Skip on_text_motion call for efficiency
+        if motion == key.MOTION_SELECT_ALL:
+            self.select_all()
+            self._nudge()
+        else:  # We use an actual text motion
+            if self.mark is None:
+                self.mark = self.position
+            self.on_text_motion(motion, True)
         return event.EVENT_HANDLED
 
     def on_mouse_scroll(self, x, y, scroll_x, scroll_y):

--- a/pyglet/text/caret.py
+++ b/pyglet/text/caret.py
@@ -386,6 +386,7 @@ class Caret:
         self._next_attributes.clear()
 
     def select_all(self) -> None:
+        """Select all text in this text entry field."""
         self._mark = 0
         self._position = len(self._layout.document.text)
         self._update()

--- a/pyglet/text/caret.py
+++ b/pyglet/text/caret.py
@@ -385,7 +385,7 @@ class Caret:
         self._update(line=line)
         self._next_attributes.clear()
 
-    def select_all(self):
+    def select_all(self) -> None:
         self._mark = 0
         self._position = len(self._layout.document.text)
         self._update()

--- a/pyglet/window/cocoa/pyglet_textview.py
+++ b/pyglet/window/cocoa/pyglet_textview.py
@@ -166,7 +166,7 @@ class PygletTextView_Implementation:
         self._window.dispatch_event("on_text_motion_select", key.MOTION_END_OF_FILE)
 
     @PygletTextView.method('v@')
-    def selectAll(self, sender):
+    def selectAll_(self, sender):
         self._window.dispatch_event("on_text_motion_select", key.MOTION_SELECT_ALL)
 
 

--- a/pyglet/window/cocoa/pyglet_textview.py
+++ b/pyglet/window/cocoa/pyglet_textview.py
@@ -165,5 +165,9 @@ class PygletTextView_Implementation:
     def moveToEndOfDocumentAndModifySelection_(self, sender):        # Mac OS X 10.6
         self._window.dispatch_event("on_text_motion_select", key.MOTION_END_OF_FILE)
 
+    @PygletTextView.method('v@')
+    def selectAll(self, sender):
+        self._window.dispatch_event("on_text_motion_select", key.MOTION_SELECT_ALL)
+
 
 PygletTextView = ObjCClass('PygletTextView')

--- a/pyglet/window/key.py
+++ b/pyglet/window/key.py
@@ -232,6 +232,14 @@ MOTION_COPY              = 7
 MOTION_PASTE             = 8
 MOTION_SELECT_ALL        = 9
 
+# Specifies motions to be sent as on_text_motion_select
+# events by non-mac platforms rather than on_text_motion.
+# Mac relies on OS-level motion detection instead of a
+# hotkey map.
+SELECT_MOTIONS = frozenset((
+    MOTION_SELECT_ALL,
+))
+
 # Number pad
 NUMLOCK       = 0xff7f
 NUM_SPACE     = 0xff80

--- a/pyglet/window/key.py
+++ b/pyglet/window/key.py
@@ -230,6 +230,7 @@ MOTION_BACKSPACE         = BACKSPACE
 MOTION_DELETE            = DELETE
 MOTION_COPY              = 7
 MOTION_PASTE             = 8
+MOTION_SELECT_ALL        = 9
 
 # Number pad
 NUMLOCK       = 0xff7f

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -37,7 +37,8 @@ _motion_map = {
     (key.BACKSPACE, False): key.MOTION_BACKSPACE,
     (key.DELETE, False): key.MOTION_DELETE,
     (key.C, True): key.MOTION_COPY,
-    (key.V, True): key.MOTION_PASTE
+    (key.V, True): key.MOTION_PASTE,
+    (key.A, True): key.MOTION_SELECT_ALL
 }
 
 

--- a/pyglet/window/win32/__init__.py
+++ b/pyglet/window/win32/__init__.py
@@ -783,7 +783,7 @@ class Win32Window(BaseWindow):
         ctrl = modifiers & key.MOD_CTRL != 0
         if (symbol, ctrl) in _motion_map and msg not in (WM_KEYUP, WM_SYSKEYUP):
             motion = _motion_map[symbol, ctrl]
-            if modifiers & key.MOD_SHIFT:
+            if modifiers & key.MOD_SHIFT or motion in key.SELECT_MOTIONS:
                 self.dispatch_event('on_text_motion_select', motion)
             else:
                 self.dispatch_event('on_text_motion', motion)

--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -1073,7 +1073,7 @@ class XlibWindow(BaseWindow):
                     modifiers_ctrl = modifiers & (key.MOD_CTRL | key.MOD_ALT)
                     motion = self._event_text_motion(symbol, modifiers)
                     if motion:
-                        if modifiers & key.MOD_SHIFT:
+                        if modifiers & key.MOD_SHIFT or motion in key.SELECT_MOTIONS:
                             self.dispatch_event('on_text_motion_select', motion)
                         else:
                             self.dispatch_event('on_text_motion', motion)
@@ -1103,7 +1103,7 @@ class XlibWindow(BaseWindow):
                 if _can_detect_autorepeat:
                     self.pressed_keys.add(symbol)
             if motion:
-                if modifiers & key.MOD_SHIFT:
+                if modifiers & key.MOD_SHIFT or motion in key.SELECT_MOTIONS:
                     self.dispatch_event('on_text_motion_select', motion)
                 else:
                     self.dispatch_event('on_text_motion', motion)

--- a/pyglet/window/xlib/__init__.py
+++ b/pyglet/window/xlib/__init__.py
@@ -67,7 +67,8 @@ _motion_map = {
     (key.BACKSPACE, False): key.MOTION_BACKSPACE,
     (key.DELETE, False):    key.MOTION_DELETE,
     (key.C, True):          key.MOTION_COPY,
-    (key.V, True):          key.MOTION_PASTE
+    (key.V, True):          key.MOTION_PASTE,
+    (key.A, True):          key.MOTION_SELECT_ALL
 }
 
 


### PR DESCRIPTION
### Changes

* Revert widget changes not related to the select all hotkey (on_resize will be added in https://github.com/pyglet/pyglet/pull/930)
* Merge in recent changes from pyglet's `master` branch
* Revert the improperly placed and platform-specific hotkey handling on `TextEntry`
* Add platform-specific select all support
* Add `MOTION_SELECT_ALL` handling in `Caret`
* Add docstring and type annotation to `Caret.select_all`